### PR TITLE
Use a python script with nvidia-ml-py to collect

### DIFF
--- a/nvidia-collect
+++ b/nvidia-collect
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# -*- mode: python; indent-tabs-mode: nil; python-indent-level: 4 -*-
+# vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=python
+
+import os
+import sys
+import time
+import argparse
+from datetime import datetime
+import pynvml
+
+def initialize_nvml():
+    """Initialize NVIDIA Management Library."""
+    try:
+        pynvml.nvmlInit()
+        return True
+    except pynvml.NVMLError as err:
+        print(f"Failed to initialize NVML: {err}")
+        return False
+
+def get_device_count():
+    """Get the number of NVIDIA devices on the system."""
+    try:
+        return pynvml.nvmlDeviceGetCount()
+    except pynvml.NVMLError as err:
+        print(f"Failed to get device count: {err}")
+        return 0
+
+def get_device_stats(device_index):
+    """Get statistics for a specific GPU device."""
+    try:
+        handle = pynvml.nvmlDeviceGetHandleByIndex(device_index)
+        name = pynvml.nvmlDeviceGetName(handle)
+
+        # Get utilization rates
+        utilization = pynvml.nvmlDeviceGetUtilizationRates(handle)
+        gpu_util = utilization.gpu
+        mem_util = utilization.memory
+
+        # Get temperature
+        temp = pynvml.nvmlDeviceGetTemperature(handle, pynvml.NVML_TEMPERATURE_GPU)
+
+        # Get memory info
+        memory = pynvml.nvmlDeviceGetMemoryInfo(handle)
+        total_mem = memory.total / (1024 * 1024)  # MiB
+        used_mem = memory.used / (1024 * 1024)    # MiB
+        free_mem = memory.free / (1024 * 1024)    # MiB
+
+        # Get power usage
+        try:
+            power_usage = pynvml.nvmlDeviceGetPowerUsage(handle) / 1000.0  # Convert from mW to W
+        except pynvml.NVMLError:
+            power_usage = 0
+
+        # Get fan speed if available
+        try:
+            fan_speed = pynvml.nvmlDeviceGetFanSpeed(handle)
+        except pynvml.NVMLError:
+            fan_speed = 0
+
+        return {
+            "name": name,
+            "gpu_util": gpu_util,
+            "mem_util": mem_util,
+            "temp": temp,
+            "total_mem": total_mem,
+            "used_mem": used_mem,
+            "free_mem": free_mem,
+            "power_usage": power_usage,
+            "fan_speed": fan_speed
+        }
+    except pynvml.NVMLError as err:
+        print(f"Failed to get stats for device {device_index}: {err}")
+        return None
+
+def print_header(device_count):
+    """Print CSV header with aligned columns."""
+    header = "timestamp, device_id, device_name, gpu_util(%), mem_util(%), temp(C), used_mem(MiB), total_mem(MiB), free_mem(MiB), power(W), fan(%)"
+    print(header)
+
+def print_stats(timestamp, device_index, stats):
+    """Print device statistics in CSV format with aligned columns."""
+    if stats:
+        row = (f"{timestamp}, {device_index}, {stats['name']}, "
+               f"{stats['gpu_util']:3d}, {stats['mem_util']:3d}, "
+               f"{stats['temp']:3d}, {stats['used_mem']:8.1f}, "
+               f"{stats['total_mem']:8.1f}, {stats['free_mem']:8.1f}, "
+               f"{stats['power_usage']:5.1f}, {stats['fan_speed']:3d}")
+        print(row)
+
+def monitor_gpus(interval, duration=None):
+    """Monitor all available GPUs at specified intervals."""
+    if not initialize_nvml():
+        return
+
+    device_count = get_device_count()
+    if device_count == 0:
+        print("No NVIDIA GPUs found.")
+        pynvml.nvmlShutdown()
+        return
+
+    print(f"Found {device_count} NVIDIA GPU(s).")
+    print_header(device_count)
+
+    try:
+        start_time = time.time()
+        while True:
+            timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+            for i in range(device_count):
+                stats = get_device_stats(i)
+                print_stats(timestamp, i, stats)
+
+            if duration and (time.time() - start_time) >= duration:
+                break
+
+            time.sleep(interval)
+
+    except KeyboardInterrupt:
+        print("\nMonitoring stopped by user.")
+    finally:
+        pynvml.nvmlShutdown()
+
+def main():
+    parser = argparse.ArgumentParser(description="Monitor NVIDIA GPU statistics")
+    parser.add_argument("-i", "--interval", type=float, default=1.0,
+                        help="Sampling interval in seconds (default: 1.0)")
+    parser.add_argument("-d", "--duration", type=float,
+                        help="Total monitoring duration in seconds (optional)")
+    parser.add_argument("-o", "--output", help="Output file (default: stdout)")
+
+    args = parser.parse_args()
+
+    if args.output:
+        sys.stdout = open(args.output, 'w')
+
+    monitor_gpus(args.interval, args.duration)
+
+    if args.output:
+        sys.stdout.close()
+
+if __name__ == "__main__":
+    main()

--- a/nvidia-post-process
+++ b/nvidia-post-process
@@ -31,39 +31,38 @@ from toolbox.metrics import log_sample
 from toolbox.metrics import finish_samples
 
 def main():
-    print('nvidia-post-process-smi')
-    # Made for the file conntrack-stats-show.txt.xz
-    # #Date        Time         gpu    pwr  gtemp  mtemp     sm    mem    enc    dec    jpg    ofa   mclk   pclk     mig_id      gi_id      ci_id    intutil     mmaact
-    # #YYYYMMDD    HH:MM:SS     Idx      W      C      C      %      %      %      %      %      %    MHz    MHz        Idx        Idx        Idx      GPM:%      GPM:%
-    # 20241120    19:14:24       0     34     34     35      0      0      0      0      0      0   1215    210          -          -          -          -          -
-    # 20241120    19:14:24       1     38     36     37      0      0      0      0      0      0   1215    210          -          -          -          0          0
-    # 20241120    19:14:27       0     34     34     35      0      0      0      0      0      0   1215    210          -          -          -          -          -
-    f = 'nvidia-smi.txt.xz'
+    print('nvidia-post-process')
+
+    # timestamp, device_id, device_name, gpu_util(%), mem_util(%), temp(C), used_mem(MiB), total_mem(MiB), free_mem(MiB), power(W), fan(%)
+    # 2025-05-16 14:51:59, 0, NVIDIA A100-SXM4-80GB,   0,   0,  31,    882.4,  81920.0,  81037.6,  65.3,   0
+    # 2025-05-16 14:51:59, 1, NVIDIA A100-SXM4-80GB,   0,   0,  29,    882.4,  81920.0,  81037.6,  63.7,   0
+
+    f = 'nvidia-output.txt.xz'
     with lzma.open(f, 'rt') as file:
         desc_tput = {'source': 'nvidia-smi', 'type': 'util', 'class': 'throughput'}
         desc_count = {'source': 'nvidia-smi', 'type': 'mclk', 'class': 'count'}
         file_id = '0'
         for line in file:
             print(line)
-            if reggy := re.search(r'^\s*(\d{,8}\s+\d{,2}:\d{,2}:\d{,2})\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+).+', line):
+            if reggy := re.search(r'^(\d{,4}-\d{,2}-\d{,2}\s+\d{,2}:\d{,2}:\d{,2}),\s+(\d+),\s+([^,]+),\s+(\d+),\s+(\d+),\s+(\d+),\s+((\d+(\.\d*)?)|(\.\d+)),\s+((\d+(\.\d*)?)|(\.\d+)),\s+((\d+(\.\d*)?)|(\.\d+)),\s+((\d+(\.\d*)?)|(\.\d+)),\s+\d+$', line):
                 print("matched")
                 end_dt = reggy.group(1)
-                names = {'id': reggy.group(2)}
+                names = {'id': reggy.group(2), 'desc' : reggy.group(3)}
                 values = {
-                    'pwr': reggy.group(3),
-                    'gtemp': reggy.group(4),
-                    'mtemp': reggy.group(5),
-                    'util': reggy.group(6),
-                    'mem': reggy.group(7) }
-                dt = datetime.strptime(end_dt, '%Y%m%d %X')
+                    'util': reggy.group(4),
+                    'temp': reggy.group(6),
+                    'mem': reggy.group(7),
+                    'pwr': reggy.group(10)
+                    }
+                dt = datetime.strptime(end_dt, '%Y-%m-%d %X')
                 end_ts = int(math.floor(dt.timestamp() * 1000))
-                for this_type in ('pwr', 'util', 'mem', 'gtemp', 'mtemp'):
+                for this_type in ('pwr', 'util', 'mem', 'temp'):
                     sample = {'end': end_ts, 'value': values[this_type]}
-                    if this_type in ('gtemp', 'mtemp'):
+                    if this_type in ('temp'):
                         this_class = 'count'
                     else:
                         this_class = 'throughput'
-                    this_desc = {'source': 'nvidia-smi', 'type': this_type, 'class': this_class}
+                    this_desc = {'source': 'nvidia', 'type': this_type, 'class': this_class}
                     log_sample(file_id, this_desc, names, sample)
             else:
                 print("NO MATCH")

--- a/nvidia-post-process
+++ b/nvidia-post-process
@@ -44,7 +44,7 @@ def main():
         file_id = '0'
         for line in file:
             print(line)
-            if reggy := re.search(r'^(\d{,4}-\d{,2}-\d{,2}\s+\d{,2}:\d{,2}:\d{,2}),\s+(\d+),\s+([^,]+),\s+(\d+),\s+(\d+),\s+(\d+),\s+((\d+(\.\d*)?)|(\.\d+)),\s+((\d+(\.\d*)?)|(\.\d+)),\s+((\d+(\.\d*)?)|(\.\d+)),\s+((\d+(\.\d*)?)|(\.\d+)),\s+\d+$', line):
+            if reggy := re.search(r'^(\d{,4}-\d{,2}-\d{,2}\s+\d{,2}:\d{,2}:\d{,2}),\s+(\d+),\s+([^,]+),\s+(\d+),\s+(\d+),\s+(\d+),\s+((\d+(\.\d*)?)|(\.\d+)),\s+((\d+(\.\d*)?)|(\.\d+)),\s+((\d+(\.\d*)?)|(\.\d+)),\s+((\d+(\.\d*)?)|(\.\d+)),\s+(\d+)$', line):
                 print("matched")
                 end_dt = reggy.group(1)
                 names = {'id': reggy.group(2), 'desc' : reggy.group(3)}
@@ -52,7 +52,7 @@ def main():
                     'util': reggy.group(4),
                     'temp': reggy.group(6),
                     'mem': reggy.group(7),
-                    'pwr': reggy.group(10)
+                    'pwr': reggy.group(19)
                     }
                 dt = datetime.strptime(end_dt, '%Y-%m-%d %X')
                 end_ts = int(math.floor(dt.timestamp() * 1000))

--- a/nvidia-start
+++ b/nvidia-start
@@ -33,17 +33,10 @@ while true; do
     esac
 done
 
-# Find out what GPUs we have
-gpus=`nvidia-smi --list-gpus | awk '{print $2}' | sed -e 's/:/,/' | tr -d '\n' | sed -e 's/,$//'`
-
-if [ -z "$gpus" ]; then
-    echo "Could not find any GPUs, exiting"
-    exit 1
-fi
 
 /bin/rm -f nvidia-pids.txt
-echo "Starting nvidia-smi"
-TZ=UTC S_TIME_FORMAT=ISO nvidia-smi dmon  --gpm-metrics 4,5 --gpm-options dm -o DT -d $interval -i $gpus >nvidia-smi.txt &
-nvidia_smi_pid=$!
-echo "$nvidia_smi_pid" >>nvidia-pids.txt
-echo "nvidia pid is $nvidia_pid"
+echo "Starting nvidia-collect"
+TZ=UTC S_TIME_FORMAT=ISO nvidia-collect --interval $interval >nvidia-output.txt &
+pid=$!
+echo "$pid" >>nvidia-pids.txt
+echo "nvidia pid is $pid"

--- a/rickshaw.json
+++ b/rickshaw.json
@@ -11,6 +11,10 @@
     "collector": {
         "files-from-controller": [
             {
+                "src": "%tool-dir%/nvidia-collect",
+                "dest": "/usr/bin/"
+            },
+            {
                 "src": "%tool-dir%/nvidia-start",
                 "dest": "/usr/bin/"
             },

--- a/workshop.json
+++ b/workshop.json
@@ -7,16 +7,16 @@
     "userenvs": [
         {
             "name": "default",
-            "requirements": [ "nvidia" ]
+            "requirements": [ "nvidia-ml-py" ]
         }
     ],
     "requirements": [
         {
-            "name": "nvidia",
-            "type": "distro",
-            "distro_info": {
+            "name": "nvidia-ml-py",
+            "type": "python3",
+            "python3_info": {
                 "packages": [
-		    "nvidia-driver-cuda"
+		    "nvidia-ml-py"
                 ]
             }
         }


### PR DESCRIPTION
- Should no longer have problems with mismatched nvidia drivers between host and container.  In fact, there is no need for drivers in the contaoner, so this works with the default userenv node (fedora-latest)
- the tool pod must have access to the GPU