### PR TITLE
fix: unused imports, wrong metric class, timezone, and stop-script bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/nvidia-post-process
+++ b/nvidia-post-process
@@ -6,13 +6,8 @@ import sys
 import os
 import lzma
 import re
-import copy
 import math
-import json
-import yaml
-import argparse
-import glob
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 TOOLBOX_HOME = os.environ.get('TOOLBOX_HOME')
@@ -38,9 +33,11 @@ def main():
     # 2025-05-16 14:51:59, 1, NVIDIA A100-SXM4-80GB,   0,   0,  29,    882.4,  81920.0,  81037.6,  63.7,   0
 
     f = 'nvidia-output.txt.xz'
+    if not os.path.exists(f):
+        print("ERROR: %s not found" % f)
+        return 1
+
     with lzma.open(f, 'rt') as file:
-        desc_tput = {'source': 'nvidia-smi', 'type': 'util', 'class': 'throughput'}
-        desc_count = {'source': 'nvidia-smi', 'type': 'mclk', 'class': 'count'}
         file_id = '0'
         for line in file:
             print(line)
@@ -54,11 +51,11 @@ def main():
                     'mem': reggy.group(7),
                     'pwr': reggy.group(19)
                     }
-                dt = datetime.strptime(end_dt, '%Y-%m-%d %X')
+                dt = datetime.strptime(end_dt, '%Y-%m-%d %X').replace(tzinfo=timezone.utc)
                 end_ts = int(math.floor(dt.timestamp() * 1000))
                 for this_type in ('pwr', 'util', 'mem', 'temp'):
                     sample = {'end': end_ts, 'value': values[this_type]}
-                    if this_type in ('temp'):
+                    if this_type in ('temp', 'mem'):
                         this_class = 'count'
                     else:
                         this_class = 'throughput'
@@ -66,7 +63,6 @@ def main():
                     log_sample(file_id, this_desc, names, sample)
             else:
                 print("NO MATCH")
-    file.close
     finish_samples()
     return(0)
 

--- a/nvidia-stop
+++ b/nvidia-stop
@@ -8,8 +8,9 @@ echo "hostname: `hostname`"
 if [ -e nvidia-pids.txt ]; then
     while read pid; do
         kill -s SIGINT $pid
+        wait $pid 2>/dev/null
     done <nvidia-pids.txt
-    find . -name "*stdout.txt" -o -name "*stderr.txt" -o -name "*.txt" | while read line; do
+    find . -name "nvidia-output.txt" -o -name "nvidia-collect-stderrout.txt" | while read line; do
 	echo "Compressing: $line"
 	xz -3 -T 0 $line
     done


### PR DESCRIPTION
## Summary
- **nvidia-post-process**: Remove 5 unused imports (yaml, copy, json, argparse, glob), classify GPU memory as `count` not `throughput`, parse timestamps as UTC to match `TZ=UTC` set in nvidia-start, add missing-file error handling, remove dead code
- **nvidia-stop**: Replace broad `find . -name "*.txt"` with explicit filenames to avoid matching the active `nvidia-stop-stderrout.txt` log, wait for killed processes to exit before compressing
- Add `.gitignore`

Closes #12

## Test plan
- [x] Verify nvidia-post-process imports are clean (no unused)
- [x] Verify `mem` metric uses `count` class
- [x] Verify UTC timestamp handling matches nvidia-start's `TZ=UTC`
- [x] Verify nvidia-stop find pattern excludes its own log file

🤖 Generated with [Claude Code](https://claude.com/claude-code)