### PR TITLE
fix: migrate nvidia post-processing to CDMMetrics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,15 +5,15 @@ Crucible tool for collecting NVIDIA GPU performance metrics (utilization, temper
 
 ## Languages
 - Bash: start/stop wrapper scripts (`nvidia-start`, `nvidia-stop`)
-- Python: GPU sampling and post-processing (`nvidia-collect`, `nvidia-post-process`)
+- Python: GPU sampling and post-processing (`nvidia-collect.py`, `nvidia-post-process.py`)
 
 ## Key Files
 | File | Purpose |
 |------|---------|
-| `nvidia-start` | Launches `nvidia-collect` in the background with configured interval |
-| `nvidia-stop` | Sends SIGINT to `nvidia-collect` and compresses output files with xz |
-| `nvidia-collect` | Initializes `pynvml`, queries GPU metrics at intervals, and writes aligned CSV output |
-| `nvidia-post-process` | Parses collected data into crucible CDM metrics (`pwr`, `util`, `mem`, `temp`) |
+| `nvidia-start` | Launches `nvidia-collect.py` in the background with configured interval |
+| `nvidia-stop` | Sends SIGINT to `nvidia-collect.py` and compresses output files with xz |
+| `nvidia-collect.py` | Initializes `pynvml`, queries GPU metrics at intervals, and writes aligned CSV output |
+| `nvidia-post-process.py` | Parses collected data into crucible CDM metrics (`pwr`, `util`, `mem`, `temp`) |
 | `rickshaw.json` | Rickshaw integration: collector scripts, blacklist/whitelist |
 | `workshop.json` | Engine image build: requires `pynvml` |
 | `tool-metadata.json` | Machine-readable description and CDM-indexed status (consumed by `crucible tools list`) |
@@ -23,14 +23,14 @@ Crucible tool for collecting NVIDIA GPU performance metrics (utilization, temper
 - `--interval <seconds>` — GPU polling interval in seconds (default: `10`)
 
 ## Architecture
-- `nvidia-start` — Launches `nvidia-collect --interval $interval >nvidia-output.txt &` in background and records PID to `nvidia-pids.txt`
-- `nvidia-collect` — Calls `pynvml.nvmlInit()`, queries all NVIDIA GPUs on the system for utilization rates, temperature, memory stats, and power usage, and prints formatted records
-- `nvidia-stop` — Sends SIGINT to `nvidia-collect`, waits for termination, and compresses `nvidia-output.txt` with xz
-- `nvidia-post-process` — Reads `nvidia-output.txt.xz`, parses CSV records, and logs CDM metrics (`source`: `nvidia`, `types`: `pwr`, `util`, `mem`, `temp`)
+- `nvidia-start` — Launches `nvidia-collect.py --interval $interval >nvidia-output.txt &` in background and records PID to `nvidia-pids.txt`
+- `nvidia-collect.py` — Calls `pynvml.nvmlInit()`, queries all NVIDIA GPUs on the system for utilization rates, temperature, memory stats, and power usage, and prints formatted records
+- `nvidia-stop` — Sends SIGINT to `nvidia-collect.py`, waits for termination, and compresses `nvidia-output.txt` with xz
+- `nvidia-post-process.py` — Reads `nvidia-output.txt.xz`, parses CSV records, and logs CDM metrics (`source`: `nvidia`, `types`: `pwr`, `util`, `mem`, `temp`)
 
 ## Testing
-- Run post-processor locally: `cd <tool-data-dir> && TOOLBOX_HOME=/opt/crucible/subprojects/core/toolbox python3 /opt/crucible/subprojects/tools/nvidia/nvidia-post-process`
-- Validate syntax: `python3 -c "import py_compile; py_compile.compile('nvidia-post-process', doraise=True); py_compile.compile('nvidia-collect', doraise=True)"`
+- Run post-processor locally: `cd <tool-data-dir> && TOOLBOX_HOME=/opt/crucible/subprojects/core/toolbox python3 /opt/crucible/subprojects/tools/nvidia/nvidia-post-process.py`
+- Validate syntax: `python3 -c "import py_compile; py_compile.compile('nvidia-post-process.py', doraise=True); py_compile.compile('nvidia-collect.py', doraise=True)"`
 - Full integration: `crucible run <run-file.json>` with nvidia tool configured on GPU-equipped node
 
 ## Conventions

--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ NVIDIA GPU performance monitoring for the [crucible](https://github.com/perftool
 
 ## Integration
 
-Nvidia runs as a profiler tool on endpoint nodes with NVIDIA GPUs. It is allowed on profiler, master, worker, and compute collector roles but blocked on client and server roles. The post-processor (`nvidia-post-process`) converts raw GPU metrics into crucible's canonical metric format.
+Nvidia runs as a profiler tool on endpoint nodes with NVIDIA GPUs. It is allowed on profiler, master, worker, and compute collector roles but blocked on client and server roles. The post-processor (`nvidia-post-process.py`) converts raw GPU metrics into crucible's canonical metric format.

--- a/nvidia-collect.py
+++ b/nvidia-collect.py
@@ -9,6 +9,8 @@ import argparse
 from datetime import datetime
 import pynvml
 
+# This executable is deployed into the controller image by rickshaw.
+
 def initialize_nvml():
     """Initialize NVIDIA Management Library."""
     try:

--- a/nvidia-collect.py
+++ b/nvidia-collect.py
@@ -9,8 +9,6 @@ import argparse
 from datetime import datetime
 import pynvml
 
-# This executable is deployed into the controller image by rickshaw.
-
 def initialize_nvml():
     """Initialize NVIDIA Management Library."""
     try:

--- a/nvidia-post-process.py
+++ b/nvidia-post-process.py
@@ -22,11 +22,11 @@ else:
         print("ERROR: <TOOLBOX_HOME>/python ('%s') does not exist!" % (p))
         exit(2)
     sys.path.append(str(p))
-from toolbox.metrics import log_sample
-from toolbox.metrics import finish_samples
+from toolbox.cdm_metrics import CDMMetrics
 
 def main():
     print('nvidia-post-process')
+    metrics = CDMMetrics()
 
     # timestamp, device_id, device_name, gpu_util(%), mem_util(%), temp(C), used_mem(MiB), total_mem(MiB), free_mem(MiB), power(W), fan(%)
     # 2025-05-16 14:51:59, 0, NVIDIA A100-SXM4-80GB,   0,   0,  31,    882.4,  81920.0,  81037.6,  65.3,   0
@@ -60,10 +60,10 @@ def main():
                     else:
                         this_class = 'throughput'
                     this_desc = {'source': 'nvidia', 'type': this_type, 'class': this_class}
-                    log_sample(file_id, this_desc, names, sample)
+                    metrics.log_sample(file_id, this_desc, names, sample)
             else:
                 print("NO MATCH")
-    finish_samples()
+    metrics.finish_samples()
     return(0)
 
 if __name__ == "__main__":

--- a/nvidia-start
+++ b/nvidia-start
@@ -35,8 +35,8 @@ done
 
 
 /bin/rm -f nvidia-pids.txt
-echo "Starting nvidia-collect"
-TZ=UTC S_TIME_FORMAT=ISO nvidia-collect --interval $interval >nvidia-output.txt &
+echo "Starting nvidia-collect.py"
+TZ=UTC S_TIME_FORMAT=ISO nvidia-collect.py --interval $interval >nvidia-output.txt &
 pid=$!
 echo "$pid" >>nvidia-pids.txt
 echo "nvidia pid is $pid"

--- a/rickshaw.json
+++ b/rickshaw.json
@@ -6,12 +6,12 @@
     },
     "tool": "nvidia",
     "controller": {
-        "post-script": "%tool-dir%nvidia-post-process"
+        "post-script": "%tool-dir%nvidia-post-process.py"
     },
     "collector": {
         "files-from-controller": [
             {
-                "src": "%tool-dir%/nvidia-collect",
+                "src": "%tool-dir%/nvidia-collect.py",
                 "dest": "/usr/bin/"
             },
             {


### PR DESCRIPTION
## Summary

- Rename nvidia-collect and nvidia-post-process to Python filenames
- Migrate NVIDIA metric logging to the CDMMetrics API
- Update nvidia-start and rickshaw deployment references
- Update README and AGENTS documentation

## Verification

- Python syntax compilation for collector and post-processor
- nvidia-start shell syntax validation
- rickshaw.json validation
- Fixture-based GPU metric post-processing
- Expected pwr, util, mem, and temp metric artifacts generated
- git diff --check

Jira: PERFNFV-307

— AI-signed: Codex | model: GPT-5 | effort: not specified